### PR TITLE
Add default .env dev configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+APP_ENV=dev
+APP_SECRET=dev-secret
+DATABASE_URL="sqlite:///%kernel.project_dir%/var/data.db"


### PR DESCRIPTION
## Summary
- add a default `.env` file for local development

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6871923b4380832a827b678f0d193444