### PR TITLE
Fix deprecated Doctrine types

### DIFF
--- a/src/Entity/Article.php
+++ b/src/Entity/Article.php
@@ -6,6 +6,7 @@ use App\Repository\ArticleRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Doctrine\DBAL\Types\Types;
 use Symfony\Component\Validator\Constraints as Assert;
 
 
@@ -17,35 +18,35 @@ class Article
     /**
      * @ORM\Id
      * @ORM\GeneratedValue
-     * @ORM\Column(type="integer")
+     * @ORM\Column(type=Types::INTEGER)
      */
     private $id;
 
     /**
-     * @ORM\Column(type="string", length=255)
+     * @ORM\Column(type=Types::STRING, length=255)
      * @Assert\Length(min = 2, max = 50)
      */
     private $title;
 
     /**
-     * @ORM\Column(type="string", length=255, unique=true)
+     * @ORM\Column(type=Types::STRING, length=255, unique=true)
      */
     private $slug;
 
     /**
-     * @ORM\Column(type="text")
+     * @ORM\Column(type=Types::TEXT)
      * @Assert\Length(min = 10)
      */
     private $content;
 
     /**
-     * @ORM\Column(type="string", length=255, nullable=true)
+     * @ORM\Column(type=Types::STRING, length=255, nullable=true)
      * @Assert\Image
      */
     private ?string $image = null;
 
     /**
-     * @ORM\Column(type="datetime")
+     * @ORM\Column(type=Types::DATETIME_MUTABLE)
      */
     private $createdAt;
 

--- a/src/Entity/Category.php
+++ b/src/Entity/Category.php
@@ -6,6 +6,7 @@ use App\Repository\CategoryRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
+use Doctrine\DBAL\Types\Types;
 
 /**
  * @ORM\Entity(repositoryClass=CategoryRepository::class)
@@ -15,17 +16,17 @@ class Category
     /**
      * @ORM\Id
      * @ORM\GeneratedValue
-     * @ORM\Column(type="integer")
+     * @ORM\Column(type=Types::INTEGER)
      */
     private $id;
 
     /**
-     * @ORM\Column(type="string", length=255)
+     * @ORM\Column(type=Types::STRING, length=255)
      */
     private $title;
 
     /**
-     * @ORM\Column(type="text", nullable=true)
+     * @ORM\Column(type=Types::TEXT, nullable=true)
      */
     private $description;
 

--- a/src/Entity/Comment.php
+++ b/src/Entity/Comment.php
@@ -4,6 +4,7 @@ namespace App\Entity;
 
 use App\Repository\CommentRepository;
 use Doctrine\ORM\Mapping as ORM;
+use Doctrine\DBAL\Types\Types;
 
 /**
  * @ORM\Entity(repositoryClass=CommentRepository::class)
@@ -13,22 +14,22 @@ class Comment
     /**
      * @ORM\Id
      * @ORM\GeneratedValue
-     * @ORM\Column(type="integer")
+     * @ORM\Column(type=Types::INTEGER)
      */
     private $id;
 
     /**
-     * @ORM\Column(type="string", length=255)
+     * @ORM\Column(type=Types::STRING, length=255)
      */
     private $author;
 
     /**
-     * @ORM\Column(type="string", length=255)
+     * @ORM\Column(type=Types::STRING, length=255)
      */
     private $content;
 
     /**
-     * @ORM\Column(type="datetime")
+     * @ORM\Column(type=Types::DATETIME_MUTABLE)
      */
     private $createdAt;
 

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -3,6 +3,7 @@
 namespace App\Entity;
 
 use Doctrine\ORM\Mapping as ORM;
+use Doctrine\DBAL\Types\Types;
 use App\Repository\UserRepository;
 use Symfony\Component\Validator\Constraints as Assert;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -19,28 +20,28 @@ class User implements UserInterface
     /**
      * @ORM\Id
      * @ORM\GeneratedValue
-     * @ORM\Column(type="integer")
+     * @ORM\Column(type=Types::INTEGER)
      */
     private $id;
 
     /**
-     * @ORM\Column(type="string", length=255)
+     * @ORM\Column(type=Types::STRING, length=255)
      * @Assert\Email()
      */
     private $email;
 
     /**
-     * @ORM\Column(type="json")
+     * @ORM\Column(type=Types::JSON)
      */
     private $roles = [];
 
     /**
-     * @ORM\Column(type="string", length=255)
+     * @ORM\Column(type=Types::STRING, length=255)
      */
     private $username;
 
     /**
-     * @ORM\Column(type="string", length=255)
+     * @ORM\Column(type=Types::STRING, length=255)
      * @Assert\Length(min="8", minMessage="Votre mot de passe doit faire minimum 8 caractères")
      */
     private $password;


### PR DESCRIPTION
## Summary
- replace deprecated Doctrine type strings with `Doctrine\DBAL\Types\Types` constants
- update `User` entity roles mapping to use `Types::JSON`

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687196ca8040832abaee6e01c5026314